### PR TITLE
added upgrade.php to allow for upgrade from 1.9 to 2.x

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -1,0 +1,36 @@
+<?php
+function xmldb_qtype_multinumerical_upgrade($oldversion = 0) {
+    global $DB;
+    $dbman = $DB->get_manager();
+
+    $result = true;
+
+    if ($result && $oldversion < 2012110100) {
+
+        // Define key questionid (foreign) to be dropped form question_multinumerical
+        $table = new xmldb_table('question_multinumerical');
+        $key = new xmldb_key('questionid', XMLDB_KEY_FOREIGN, array('questionid'), 'questionid', array('id'));
+
+        // Launch drop key questionid
+        $dbman->drop_key($table, $key);
+
+        // Rename field questionid on table question_multinumerical to NEWNAMEGOESHERE
+        $table = new xmldb_table('question_multinumerical');
+        $field = new xmldb_field('questionid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null, 'id');
+
+        // Launch rename field questionid
+        $dbman->rename_field($table, $field, 'question');
+
+
+
+        // Define key question (foreign) to be added to question_multinumerical
+        $table = new xmldb_table('question_multinumerical');
+        $key = new xmldb_key('question', XMLDB_KEY_FOREIGN, array('question'), 'question', array('id'));
+
+        // Launch add key questionid
+        $dbman->add_key($table, $key);
+
+        // multinumerical savepoint reached
+        upgrade_plugin_savepoint(true, 2012110100, 'qtype', 'multinumerical');
+    }
+}


### PR DESCRIPTION
When upgrading from Moodle 1.9 the database doesn't get update to match the new question engine. Specifically the field 'questionid' does not get renamed to 'question'. Consequently the adding of new questions of this type results in a database error.
The provided upgrade.php should fix this issue by renaming the field.
